### PR TITLE
Cherry-pick backport commits using `-x` option

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -108,7 +108,7 @@ const backportOnce = async ({
   await git("switch", "--create", head);
   try {
     info(`Cherry-picking range: ${commitToBackport}`);
-    await git("cherry-pick", commitToBackport);
+    await git("cherry-pick", "-x", commitToBackport);
   } catch (error: unknown) {
     await git("cherry-pick", "--abort");
     throw error;
@@ -163,7 +163,7 @@ const getFailedBackportCommentBody = ({
     "# Create a new branch",
     `git switch --create ${head}`,
     "# Cherry-pick the merged commits of this pull request and resolve the conflicts",
-    `git cherry-pick ${commitToBackport}`,
+    `git cherry-pick -x ${commitToBackport}`,
     "# Push it to GitHub",
     `git push --set-upstream origin ${head}`,
     "# Go back to the original working tree",


### PR DESCRIPTION
This commit updates the backport action to cherry-pick the commit(s) to
be backported using the `-x` option, such that the following message is
appended to the end of the commit messages:

  (cherry picked from commit ...)

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>