### PR TITLE
Remove warning when rebase merge option is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "1.1.1-2",
+  "version": "1.1.1-3",
   "license": "MIT",
   "files": [
     "action.yml",

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -55,7 +55,7 @@ const getBackportBaseToHead = ({
   return baseToHead;
 };
 
-const warnIfSquashIsNotTheOnlyAllowedMergeMethod = async ({
+const warnIfMergeCommitIsAllowedMergeMethod = async ({
   github,
   owner,
   repo,
@@ -65,14 +65,14 @@ const warnIfSquashIsNotTheOnlyAllowedMergeMethod = async ({
   repo: string;
 }) => {
   const {
-    data: { allow_merge_commit, allow_rebase_merge },
+    data: { allow_merge_commit },
   } = await github.repos.get({ owner, repo });
-  if (allow_merge_commit || allow_rebase_merge) {
+  if (allow_merge_commit) {
     warning(
       [
-        "Your repository allows merge commits and rebase merging.",
+        "Your repository allows merge commits.",
         " However, Backport only supports rebased and merged pull requests and squashed and merged pull requests.",
-        " Consider only allowing squash merging.",
+        " Consider only allowing rebase and squash merging.",
         " See https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github for more information.",
       ].join("\n"),
     );
@@ -222,7 +222,7 @@ const backport = async ({
 
   const github = getOctokit(token);
 
-  await warnIfSquashIsNotTheOnlyAllowedMergeMethod({ github, owner, repo });
+  await warnIfMergeCommitIsAllowedMergeMethod({ github, owner, repo });
 
   // The merge commit SHA is actually not null.
   const _commit = String(mergeCommitSha);


### PR DESCRIPTION
The backport action currently warns when the "merge commit" or "rebase
merge" methods are enabled for the repository.

Since 259f9d53f6bf71bca8d017795a50bf3f89eb9b72, backporting a pull
request with multiple commits that has been merged using the "rebase
merge" method is allowed, and therefore enabling the "rebase merge"
method should not generate any warnings.

This commit updates the warning logic accordingly.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>