### PR TITLE
Add support for multiple commits in rebase and merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Backport is a [JavaScript GitHub Action](https://help.github.com/en/articles/about-actions#javascript-actions) to backport a pull request by simply adding a label to it.
 
-It can backport [rebased and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits) pull requests with a single commit and [squashed and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) pull requests.
+It can backport [rebased and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits) pull requests and [squashed and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) pull requests.
 It thus integrates well with [Autosquash](https://github.com/marketplace/actions/autosquash).
 
 # Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.3-1",
+  "version": "2.0.3-2",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
By using a range, add support for multiple commits when using the rebase and merge strategy instead of supporting a single one.


(cherry picked from commit 259f9d53f6bf71bca8d017795a50bf3f89eb9b72)

Reworked to be compatible with the v2.0.3 release.